### PR TITLE
Update Dockerfile to reflect currently available jdk-17 images

### DIFF
--- a/stock-market-service/Dockerfile
+++ b/stock-market-service/Dockerfile
@@ -9,6 +9,6 @@ COPY src /app/src
 RUN mvn -f /app/pom.xml clean package -DskipTests
 
 # Run stage
-FROM openjdk:17-jdk-alpine
+FROM amazoncorretto:17.0.7-alpine
 COPY --from=build /app/target/stock-market-service-0.0.1-SNAPSHOT.jar /app/app.jar
 ENTRYPOINT ["java", "-jar","/app/app.jar", "--spring.config.name=application-docker"]


### PR DESCRIPTION
The openjdk-17 image is no longer available in the repo mentioned. I'm updating the Dockerfile to reference the latest and properly maintained image for jdk-17. 
I ran into errors when building the service and this change helped me fix it and run it. 